### PR TITLE
Add Agents SDK manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ curl -X POST "http://localhost:5050/make-call" -H "Content-Type: application/jso
 
 The AI's behavior can be customized by modifying the system prompt in `prompts/system_prompt.txt`.
 
+### Agents Manifest
+
+The `openai.yaml` file defines approved function tools for the OpenAI Agents SDK. Only the
+`offer_time_slots`, `schedule_meeting`, and `end_call` actions may be invoked by the model.
+
 ## API Endpoints
 
 - `GET /`: Health check endpoint

--- a/openai.yaml
+++ b/openai.yaml
@@ -1,0 +1,42 @@
+schema_version: v1
+name_for_human: AI Call Agent
+name_for_model: ai_call_agent
+instructions: |
+  Use the provided tools to manage calls. Only call approved functions when necessary.
+tools:
+  - type: function
+    function:
+      name: offer_time_slots
+      description: Offer two or more available meeting time options to the prospect.
+      parameters:
+        type: object
+        properties:
+          prospect_name:
+            type: string
+            description: Name of the person being called
+        required:
+          - prospect_name
+  - type: function
+    function:
+      name: schedule_meeting
+      description: Book a meeting for the prospect using the selected time slot.
+      parameters:
+        type: object
+        properties:
+          prospect_name:
+            type: string
+            description: Name of the person being called
+          time_slot:
+            type: string
+            description: The time slot chosen by the prospect
+        required:
+          - prospect_name
+          - time_slot
+  - type: function
+    function:
+      name: end_call
+      description: Politely conclude the call once scheduling is complete or the prospect declines.
+      parameters:
+        type: object
+        properties: {}
+        required: []


### PR DESCRIPTION
## Summary
- define `openai.yaml` manifest with approved function tools
- document the manifest in README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_685c52026250832d821575be7b631169