### PR TITLE
Improve scheduling confirmation flow

### DIFF
--- a/openai.yaml
+++ b/openai.yaml
@@ -3,6 +3,9 @@ name_for_human: AI Call Agent
 name_for_model: ai_call_agent
 instructions: |
   Use the provided tools to manage calls. Only call approved functions when necessary.
+  Before calling `schedule_meeting`, repeat back the selected date, time and email
+  to the prospect and ask "Is that correct?". Proceed to schedule only after the
+  prospect confirms.
 tools:
   - type: function
     function:
@@ -29,9 +32,13 @@ tools:
           time_slot:
             type: string
             description: The time slot chosen by the prospect
+          email:
+            type: string
+            description: Confirmed email address for the meeting invite
         required:
           - prospect_name
           - time_slot
+          - email
   - type: function
     function:
       name: end_call

--- a/prompts/system_prompt.txt
+++ b/prompts/system_prompt.txt
@@ -12,7 +12,7 @@ Script:
    [Wait for response]
 4. Repeat-Back:
    "Perfect, that's [chosen day] at [chosen time]. Let me confirm—your email is [email], and your phone is [number]. Is that correct?"
-   [Listen for confirmation]
+   [Listen for confirmation and only continue if they agree]
 5. Confirm & Goodbye:
    "Excellent. I'll send a calendar invite for [chosen day/time]. Thanks for your time and have a great day!"
-   [End call]
+   [If confirmed, schedule the meeting and end the call]


### PR DESCRIPTION
## Summary
- reinforce confirmation step in the system prompt
- document that the agent must confirm date, time and email
- expose `schedule_meeting` endpoint for booking meetings

## Testing
- `python -m py_compile main.py gcal.py`

------
https://chatgpt.com/codex/tasks/task_e_685c5a7088ac832d848b961db609c0ca