### PR TITLE
Add silence detection to Twilio stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A powerful integration that combines OpenAI's Realtime API with Twilio's Voice s
 - WebSocket-based communication
 - Support for G711 ULAW audio format
 - Interrupt handling for natural conversation flow
+- Silence detection with auto prompt and hangup
 - Session management and real-time updates
 - Structured JSON responses from GPT-4o using
   `response_format=json` in the WebSocket connection


### PR DESCRIPTION
## Summary
- add `media_stream_timeout` attribute to `<Stream>` for silence detection
- detect `media_stream_timeout` events during calls
- prompt on first silence and hang up on second
- document silence detection feature

## Testing
- `python -m py_compile main.py gcal.py`

------
https://chatgpt.com/codex/tasks/task_e_685c5b6f1694832da88f41e8479c2e2e