### PR TITLE
Persist call transcripts as text

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A powerful integration that combines OpenAI's Realtime API with Twilio's Voice s
 - Structured JSON responses from GPT-4o using
   `response_format=json` in the WebSocket connection
 - Call summaries persisted to SQLite or Postgres
-- Call transcripts saved to the `transcripts/` directory
+- Call transcripts saved to the `transcripts/` directory, including `call_<id>.txt` plain text logs for QA review
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- capture human/AI dialog in a `call_<id>.txt` file after each call
- document new plain text transcript files in README

## Testing
- `python -m py_compile main.py db.py gcal.py`

------
https://chatgpt.com/codex/tasks/task_e_685c5ff19f0c832d9fdf0f610f3ce07d