### PR TITLE
Add microphone-based demo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ The `openai.yaml` file defines approved function tools for the OpenAI Agents SDK
 - `POST /offer-time-slots`: Return available slots for today (used by the agent)
 - `POST /end-call`: Hang up the current call (used by the agent)
 
+## Demo Mode (No Twilio or Calendar)
+
+You can test the voice experience locally without any phone or calendar setup:
+
+```bash
+pip install -r requirements.txt
+python demo_mode.py
+```
+
+Talk into your microphone and the agent will reply using the OpenAI Realtime API.
+Available meeting slots are defined inside `demo_mode.py` and do not require
+Google Calendar.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.

--- a/demo_mode.py
+++ b/demo_mode.py
@@ -1,0 +1,110 @@
+import asyncio
+import json
+import base64
+import os
+import audioop
+
+import sounddevice as sd
+import websockets
+import structlog
+from dotenv import load_dotenv
+
+
+def load_prompt(file_name: str) -> str:
+    path = os.path.join(os.path.dirname(__file__), "prompts", f"{file_name}.txt")
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read().strip()
+
+
+load_dotenv()
+logger = structlog.get_logger()
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+VOICE = "echo"
+SYSTEM_MESSAGE = load_prompt("system_prompt")
+
+# Hard-coded availability for demo mode
+AVAILABLE_SLOTS = [
+    "10:00 AM - 10:30 AM",
+    "2:00 PM - 2:30 PM",
+    "4:00 PM - 4:30 PM",
+]
+
+
+async def send_session_update(ws):
+    instructions = SYSTEM_MESSAGE
+    formatted = "\n".join(f"- {s}" for s in AVAILABLE_SLOTS)
+    instructions += f"\n\nToday's available slots:\n{formatted}"
+    session_update = {
+        "type": "session.update",
+        "session": {
+            "input_audio_format": "g711_ulaw",
+            "output_audio_format": "g711_ulaw",
+            "voice": VOICE,
+            "instructions": instructions,
+            "modalities": ["text", "audio"],
+            "temperature": 0.2,
+        },
+    }
+    await ws.send(json.dumps(session_update))
+
+
+def encode_chunk(data: bytes) -> str:
+    ulaw = audioop.lin2ulaw(data, 2)
+    return base64.b64encode(ulaw).decode()
+
+
+def decode_chunk(b64: str) -> bytes:
+    ulaw = base64.b64decode(b64)
+    return audioop.ulaw2lin(ulaw, 2)
+
+
+async def demo_conversation():
+    if not OPENAI_API_KEY:
+        raise ValueError("OPENAI_API_KEY not set")
+
+    uri = (
+        "wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01"
+        "&response_format=json"
+    )
+    async with websockets.connect(
+        uri,
+        extra_headers={
+            "Authorization": f"Bearer {OPENAI_API_KEY}",
+            "OpenAI-Beta": "realtime=v1",
+        },
+    ) as ws:
+        await send_session_update(ws)
+        loop = asyncio.get_running_loop()
+        q: asyncio.Queue[bytes] = asyncio.Queue()
+
+        def callback(indata, frames, time, status):
+            loop.call_soon_threadsafe(q.put_nowait, bytes(indata))
+
+        with sd.RawInputStream(
+            samplerate=8000, channels=1, dtype="int16", callback=callback
+        ):
+            with sd.RawOutputStream(
+                samplerate=8000, channels=1, dtype="int16"
+            ) as out:
+
+                async def sender():
+                    while True:
+                        chunk = await q.get()
+                        payload = {
+                            "type": "input_audio_buffer.append",
+                            "audio": encode_chunk(chunk),
+                        }
+                        await ws.send(json.dumps(payload))
+
+                async def receiver():
+                    async for message in ws:
+                        resp = json.loads(message)
+                        if resp["type"] == "response.audio.delta" and resp.get("data"):
+                            out.write(decode_chunk(resp["data"]))
+
+                await asyncio.gather(sender(), receiver())
+
+
+if __name__ == "__main__":
+    asyncio.run(demo_conversation())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ google-auth = "2.29.0"
 google-auth-httplib2 = "0.2.0"
 guardrails-ai = "0.6.6"
 SQLAlchemy = "2.0.30"
+sounddevice = "0.4.6"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,5 @@ google-auth==2.29.0
 google-auth-httplib2==0.2.0
 guardrails-ai==0.6.6
 SQLAlchemy==2.0.30
+
+sounddevice==0.4.6


### PR DESCRIPTION
## Summary
- add optional `demo_mode.py` script for local voice demos
- document running demo mode in README
- include `sounddevice` dependency in project files

## Testing
- `python -m py_compile demo_mode.py main.py gcal.py db.py metrics.py`
- `python demo_mode.py` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9c0af4c8832db7018ac588a95733